### PR TITLE
edit:create.blade.php ワイヤーフレームに合わせてデザインと整える

### DIFF
--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -2,8 +2,11 @@
     @include('components.task-header')
         <main class="text-custom-gray flex flex-grow">
             <div class="container px-24 py-5 mx-auto">
-                <div class="text-center mb-10">
-                    <h1 class="text-h1 font-bold mb-4 tracking-[0.5em]">きょうのおやくそく</h1>
+                <div class="relative mb-10">
+                    <h1 class="text-h1 font-bold text-center indent-[0.5em] tracking-[0.5em]">おやくそく登録</h1>
+                    <a href="{{ route('tasks.index') }}" class="absolute right-0 top-1/2 -translate-y-1/2 bg-green-400 text-white  text-xl px-6 py-2 indent-[0.4em] tracking-[0.4em] rounded-full hover:bg-green-500 shadow">
+                        戻る
+                    </a>
                 </div>
                 @if (session('success'))
                     <div class="message">{{ session('success')}}</div>
@@ -17,33 +20,21 @@
                         <button data-tab="2" class="js-tab-button w-[216px] px-6 py-2 rounded-t-lg bg-custom-blue">ゆいと</button>
                     </div>
                     <!-- タスク表示部分 -->
-                    <div data-panel="0" class="js-tab-panel1 flex flex-col justify-between bg-gray-100 border-custom-gray text-center font-medium h-[60vh] border-2 overflow-y-auto">
-                        <div class="flex flex-col gap-4 mt-5 px-20">
+                    <div data-panel="0" class="js-tab-panel1 flex flex-col justify-between bg-gray-100 border-custom-gray text-center font-medium h-[60vh] px-20 py-10 border-2 overflow-y-auto">
+                        <div class="flex flex-col gap-4 px-20">
                             @for ($i = 0; $i < 5; $i++)
-                                <div class="task flex justify-between items-center mx-2 px-20 py-1">
-                                    <div class="task-name tracking-[0.5em] text-left">
-
+                                <div class="task flex justify-between items-center py-2">
+                                        <input type="type" class="task-name tracking-[0.5em] w-4/5 border-2">
                                         {{-- {{$task->contents}} --}}
-                                    </div>
-                                    <div class="judge-button-area flex justify-center items-center gap-2 text-white w-1/4">
-                                        <button data-result="true" class="js-judge-button w-24 h-10 bg-custom-pink rounded-full hover:bg-custom-pink/50">◯</button>
-                                        <button data-result="false" class="js-judge-button w-24 h-10 bg-custom-blue rounded-full hover:bg-custom-blue">✖︎</button>
-                                    </div>
-                                    <div class="js-judge-wrapper w-[200px] text-center bg-white indent-[0.2em] tracking-[0.2em] hidden">
-                                        <span data-result="true" class="text-yellow-400 hidden">★&nbsp;<span class="text-custom-gray">できた</span>&nbsp;★</span>
-                                        <span data-result="false" class="text-custom-gray hidden">またあした</span>
+                                    <div class="judge-button-area flex justify-center items-center text-white w-1/4">
+                                        <button data-result="false" class="js-judge-button w-3/4 h-10 bg-custom-blue indent-[0.4em] tracking-[0.4em] rounded-full hover:bg-custom-blue">消す</button>
                                     </div>
                                 </div>
                             @endfor
                         </div>
-                        <button class="js-reward-button block text-3xl text-white text-center font-bold bg-yellow-400 mx-auto mt-10 py-4 px-6 rounded-full w-full max-w-2xl indent-[0.4em] tracking-[0.4em] disabled:opacity-50 disabled:cursor-not-allowed" disabled>
-                            ★<span class="text-custom-gray disabled:text-custom-gray/40">ごほうびガチャ</span>★
+                        <button class="js-reward-button block text-3xl text-white text-center font-bold bg-custom-pink mx-auto mt-10 py-4 px-6 rounded-full w-full max-w-2xl indent-[0.4em] tracking-[0.4em]">
+                            登録
                         </button>
-                        <div class="flex justify-center items-center gap-8 text-white text-lg font-bold py-2 mb-2">
-                            <a href="#" class="w-[200px] px-4 py-2 bg-green-400 border border-transparent rounded-full hover:bg-green-400/60">約束の登録・編集</a>
-                            <a href="#" class="w-[200px] px-4 py-2 bg-custom-pink border border-transparent rounded-full hover:bg-custom-pink/50 indent-[0.4em] tracking-[0.4em]">たからばこ</a>
-                            <button id="reset-button" class="w-[200px] px-4 py-2 bg-custom-blue border border-transparent rounded-full hover:bg-custom-blue/50 indent-[0.4em] tracking-[0.4em]">リセット</button>
-                        </div>
                     </div>
                     <div data-panel="1" class="js-tab-panel1 flex flex-col justify-between bg-gray-100 border-custom-gray text-center font-medium h-[60vh] border-2 overflow-y-auto hidden">
                         <button class="block text-3xl text-white text-center font-bold bg-yellow-400 mx-auto mt-10 py-4 px-6 rounded-full w-full max-w-2xl indent-[0.4em] tracking-[0.4em] disabled:opacity-50 disabled:cursor-not-allowed" disabled>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -22,14 +22,14 @@
                             @for ($i = 0; $i < 5; $i++)
                                 <div class="task flex justify-between items-center mx-2 px-20 py-1">
                                     <div class="task-name tracking-[0.5em] text-left">
-                                        はみがきを
+                                        ああああああああああああああああ
                                         {{-- {{$task->contents}} --}}
                                     </div>
                                     <div class="judge-button-area flex justify-center items-center gap-2 text-white w-1/4">
                                         <button data-result="true" class="js-judge-button w-24 h-10 bg-custom-pink rounded-full hover:bg-custom-pink/50">◯</button>
                                         <button data-result="false" class="js-judge-button w-24 h-10 bg-custom-blue rounded-full hover:bg-custom-blue">✖︎</button>
                                     </div>
-                                    <div class="js-judge-wrapper w-[200px] text-center bg-white indent-[0.2em] tracking-[0.2em] hidden">
+                                    <div class="js-judge-wrapper w-[250px] text-center bg-white indent-[0.2em] tracking-[0.2em] hidden">
                                         <span data-result="true" class="text-yellow-400 hidden">★&nbsp;<span class="text-custom-gray">できた</span>&nbsp;★</span>
                                         <span data-result="false" class="text-custom-gray hidden">またあした</span>
                                     </div>


### PR DESCRIPTION
# edit:create.blade.php ワイヤーフレームに合わせてデザインと整える
- 削除ボタンを→消すボタンに変更（フォーム内のテキストをリセットするだけなので）
- 消すボタン、戻るボタンのフォントサイズを16px→20pxに変更（視認性の観点から）
- tab-panel1のみを整備。他のタブパネルはタスク登録→実装後、整備